### PR TITLE
Add a YAML map to allow for custom tags and items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.houtknots</groupId>
   <artifactId>bluemaptraincartsconnector</artifactId>
-  <version>1.20.6-v1</version>
+  <version>1.20.6-v2</version>
   <packaging>jar</packaging>
 
   <name>Bluemap Traincarts Connector</name>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,22 +13,15 @@ connectorShowTaggedOnly: true
 
 # A list of tags set to a Train which indicates whether the Train should be
 # displayed on the BlueMap.
-# Default: [bluemap, Bluemap, BlueMap]
-connectorTags:
-  - bluemap
-  - Bluemap
-  - BlueMap
+# Make sure to put the icons files in the "bluemap/web/assets/" directory.
+tagMap:
+  bluemap: "assets/btc-minecart-pio.png"
+  bluemapstorage: "assets/btc-storage-pio.png"
 
-connectorStorageTags:
-  - bluemapstorage
-  - Bluemapstorage
-  - BlueMapStorage
-
-# The Icon used by BlueMap to display the Trains with, found in the 
-# "bluemap/web/assets/" directory
-# Default: "assets/minecart-pio.png"
-connectorTrainIcon: "assets/btc-minecart-pio.png"
-connectorStorageTrainIcon: "assets/btc-storage-pio.png"
+# The default icon for the TrainCart on the BlueMap
+# Make sure to put the icons files in the "bluemap/web/assets/" directory.
+# Default: "assets/btc-minecart-pio.png"
+defaultTrainIcon: "assets/btc-minecart-pio.png"
 
 # The ID for the TrainCarts BlueMap MarkerSet
 # Default: traincarts


### PR DESCRIPTION
- Change the tag mapping to a key, value pair in the new var tagMap.
- Allow for custom tags to be used by adding them to the tagMap in the config.yml file.
- Allow for custom icons to be used by assigning them to a key, value pair in the config.yml file